### PR TITLE
Add rimraf, remove operations as dependencies

### DIFF
--- a/jest-e2e.config.js
+++ b/jest-e2e.config.js
@@ -3,7 +3,6 @@ const config = require('./jest.config');
 // eslint-disable-next-line functional/immutable-data
 module.exports = {
   ...config,
-  name: 'e2e',
   displayName: 'e2e',
   setupFiles: ['<rootDir>/test/setup/init/set-define-property.ts'],
   testMatch: ['**/?(*.)+(feature).[tj]s?(x)'],

--- a/jest-unit.config.js
+++ b/jest-unit.config.js
@@ -4,7 +4,6 @@ const config = require('./jest.config');
 module.exports = {
   ...config,
   displayName: 'unit',
-  name: 'unit',
   setupFiles: ['<rootDir>/test/setup/init/set-define-property.ts'],
   testMatch: ['**/?(*.)+(spec|test).[tj]s?(x)'],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -182,7 +182,7 @@ module.exports = {
   //   "\\.pnp\\.[^\\/]+$"
   // ],
 
-  // An array of regexp pattern strings that are matched against all modules before the moduxle loader will automatically return a mock for them
+  // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
   // unmockedModulePathPatterns: undefined,
 
   // Indicates whether each individual test should be reported during the run

--- a/jest.config.js
+++ b/jest.config.js
@@ -182,7 +182,7 @@ module.exports = {
   //   "\\.pnp\\.[^\\/]+$"
   // ],
 
-  // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
+  // An array of regexp pattern strings that are matched against all modules before the moduxle loader will automatically return a mock for them
   // unmockedModulePathPatterns: undefined,
 
   // Indicates whether each individual test should be reported during the run

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "husky": "^8.0.1",
     "jest": "^29.0.1",
     "prettier": "^2.7.1",
+    "rimraf": "^3.0.2",
     "ts-jest": "^28.0.8",
     "ts-node": "^10.9.1",
     "typescript": "4.6.4"

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "lint": "yarn run lint:eslint && yarn prettier:check",
     "lint:eslint": "eslint . --ext .js,.ts",
     "lint:eslint:fix": "eslint . --ext .js,.ts --fix",
-    "test": "jest --selectProjects unit",
-    "test:e2e": "SILENCE_LOGGER=true jest --selectProjects e2e --runInBand",
+    "test": "jest --config jest.config.js --selectProjects unit",
+    "test:e2e": "jest --selectProjects e2e --runInBand",
     "prepare": "husky install"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api3/operations-utilities",
-  "version": "0.0.1",
+  "version": "0.0.1-e9411c1629a32b4033eb4968fb72f63896057808",
   "description": "Utilities common to API3 operations",
   "main": "./dist/index.js",
   "types": "./dist/index.js",
@@ -53,10 +53,12 @@
     "typescript": "4.6.4"
   },
   "dependencies": {
-    "@api3/operations": "^0.0.1-785b20f7ad527ae63c0f47f2a876da6c15c9a437",
+    "@api3/airnode-protocol-v1": "^0.8.0",
     "@ethersproject/experimental": "^5.7.0",
+    "@lifeomic/attempt": "^3.0.3",
     "axios": "^0.27.2",
     "ethers": "^5.7.0",
+    "lodash": "^4.17.21",
     "pg": "^8.8.0",
     "pg-format": "^1.0.4",
     "source-map-support": "^0.5.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api3/operations-utilities",
-  "version": "0.0.1-e9411c1629a32b4033eb4968fb72f63896057808",
+  "version": "0.0.1",
   "description": "Utilities common to API3 operations",
   "main": "./dist/index.js",
   "types": "./dist/index.js",

--- a/src/evm.test.ts
+++ b/src/evm.test.ts
@@ -1,0 +1,27 @@
+import { resolveChainId, resolveChainName } from './evm';
+
+describe('it tests the evm module', () => {
+  it('resolves a valid chain ID to a name', () => {
+    const resolvedChainName = resolveChainName('1');
+
+    expect(resolvedChainName).toEqual('mainnet');
+  });
+
+  it('resolves an unknown chain ID to a name', () => {
+    const resolvedChainName = resolveChainName('3820372938292');
+
+    expect(resolvedChainName).toBeUndefined();
+  });
+
+  it('resolves an unknown chain name to an ID', () => {
+    const resolvedChainId = resolveChainId('unknown-chain');
+
+    expect(resolvedChainId).toBeUndefined();
+  });
+
+  it('resolves a valid chain name to an ID', () => {
+    const resolvedChainId = resolveChainId('mainnet');
+
+    expect(resolvedChainId).toEqual('1');
+  });
+});

--- a/src/evm.ts
+++ b/src/evm.ts
@@ -3,6 +3,8 @@ import { chainNames } from '@api3/airnode-protocol-v1/deployments/references.jso
 import { EthValue } from './types';
 import { log } from './logging';
 
+const chainReferences = chainNames as Record<string, string>;
+
 export const doTimeout = (interval: number) => new Promise((resolve) => setTimeout(() => resolve(null), interval));
 
 export const convertEtherValue = (input: EthValue) => parseUnits(`${input.amount}`, input.units);
@@ -15,9 +17,8 @@ export const exit = (code = 0) => {
 export const isCloudFunction = () => process.env.LAMBDA_TASK_ROOT || process.env.FUNCTION_TARGET;
 
 export const resolveChainName = (chainId: string) => {
-  const chainName = Object.entries(chainNames).find(([key]) => key === chainId);
-  if (chainName && chainName[1]) {
-    return chainName[1];
+  if (chainReferences[chainId]) {
+    return chainReferences[chainId];
   }
 
   log('Invalid or unknown chain', 'INFO', {

--- a/src/evm.ts
+++ b/src/evm.ts
@@ -1,8 +1,7 @@
 import { parseUnits } from 'ethers/lib/utils';
-import { OperationsRepository } from '@api3/operations';
-import { readOperationsRepository } from '@api3/operations/dist/utils/read-operations';
+import { chainNames } from '@api3/airnode-protocol-v1/deployments/references.json';
 import { EthValue } from './types';
-import { log, logTrace } from './logging';
+import { log } from './logging';
 
 export const doTimeout = (interval: number) => new Promise((resolve) => setTimeout(() => resolve(null), interval));
 
@@ -15,13 +14,10 @@ export const exit = (code = 0) => {
 
 export const isCloudFunction = () => process.env.LAMBDA_TASK_ROOT || process.env.FUNCTION_TARGET;
 
-export const resolveChainName = (chainId: string, operationsRepository?: OperationsRepository) => {
-  const operations = operationsRepository ?? readOperationsRepository();
-
-  const chainName = Object.values(operations.chains).find((chain) => chain.id === chainId)?.name;
-
-  if (chainName) {
-    return chainName;
+export const resolveChainName = (chainId: string) => {
+  const chainName = Object.entries(chainNames).find(([key]) => key === chainId);
+  if (chainName && chainName[1]) {
+    return chainName[1];
   }
 
   log('Invalid or unknown chain', 'INFO', {
@@ -29,16 +25,12 @@ export const resolveChainName = (chainId: string, operationsRepository?: Operati
     description: `Please check the config and/or resolveChainName function: ${chainId}`,
     priority: 'P2',
   });
-  return null;
 };
 
-export const resolveChainId = (chainName: string, operationsRepository?: OperationsRepository) => {
-  const operations = operationsRepository ?? readOperationsRepository();
-
-  const chainId = Object.values(operations.chains).find((chain) => chain.name === chainName)?.id;
-
-  if (chainId) {
-    return chainId;
+export const resolveChainId = (chainName: string) => {
+  const chainId = Object.entries(chainNames).find(([_key, value]) => value === chainName);
+  if (chainId && chainId[0]) {
+    return chainId[0];
   }
 
   log('Invalid or unknown chain', 'INFO', {
@@ -47,21 +39,4 @@ export const resolveChainId = (chainName: string, operationsRepository?: Operati
     description: `Please check the config and/or resolveChainId function: ${chainName}`,
     priority: 'P2',
   });
-  return null;
-};
-
-export const resolveExplorerUrlByName = async (
-  explorerUrls: Record<string, string>,
-  chainName: string,
-  operationsRepository?: OperationsRepository
-) => {
-  const chainId = resolveChainId(chainName, operationsRepository);
-
-  const explorerUrl = explorerUrls[chainId as string];
-
-  if (chainId && !explorerUrl) {
-    logTrace(`Unable to find explorer URL for chain: ${resolveChainName(chainId, operationsRepository)}`);
-  }
-
-  return explorerUrl;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,17 +1,9 @@
-import { WalletType } from '@api3/operations';
 import { BigNumber } from 'ethers';
 import { NonceManager } from '@ethersproject/experimental';
 
 export interface EthValue {
   amount: number;
   units: 'wei' | 'kwei' | 'mwei' | 'gwei' | 'szabo' | 'finney' | 'ether';
-}
-
-export interface WalletStatus {
-  address: string;
-  balance: BigNumber;
-  walletType: WalletType;
-  chainName: string;
 }
 
 export type ExtendedWalletWithMetadata = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,71 +10,12 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@api3/airnode-abi@^0.7.5":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@api3/airnode-abi/-/airnode-abi-0.7.5.tgz#f8d6ec2cad02e65105c74841adf77b0cd1e56ff4"
-  integrity sha512-RGey3Siz3iarK5u7dokGwssNRgRQnqZINLcT0O7+R6iM5G9ey5kLp8HMU8MWD+EUoRq/wc7rG6Cst51Z4uZbrw==
+"@api3/airnode-protocol-v1@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@api3/airnode-protocol-v1/-/airnode-protocol-v1-0.8.0.tgz#0e073d3f3f38316bedf6578dd28ab3731797c539"
+  integrity sha512-EVfjg+iyA082PAGt3BI1DU+Yc1GPBJYR9S2EaGf+0XXTxYxB6cvOIiG1tcr1MVyG3Bt2IGH9r4IYnJR+bx8RiQ==
   dependencies:
-    ethers "^5.4.5"
-    lodash "^4.17.21"
-
-"@api3/airnode-admin@^0.7.2":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@api3/airnode-admin/-/airnode-admin-0.7.5.tgz#466bfe6e06b8f4168f3bd2eda1901add29ff564e"
-  integrity sha512-TwzloqW7utt9SvC1RgyHHko4hlX1GKm1DdLaXLdUFJhWgwar+dTkryQQMN2ijv1FHbBKXWS0xJMdv2VV3Phz3g==
-  dependencies:
-    "@api3/airnode-abi" "^0.7.5"
-    "@api3/airnode-protocol" "^0.7.5"
-    "@api3/airnode-utilities" "^0.7.5"
-    "@api3/airnode-validator" "^0.7.5"
-    ethers "^5.4.5"
-    lodash "^4.17.21"
-    yargs "^17.0.1"
-
-"@api3/airnode-protocol@^0.7.5":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@api3/airnode-protocol/-/airnode-protocol-0.7.5.tgz#819186e6098d413dd5ee91da3d03c56103711ce2"
-  integrity sha512-Z5QEFlHPI1CfNewWmJt+6RW/tppbpXS9fSF+tIGchfiJQnZ50ojHDICZj40X38rdAu9QCnVjUAEPoNOb6pv0SQ==
-  dependencies:
-    "@openzeppelin/contracts" "4.4.2"
-    ethers "^5.4.5"
-
-"@api3/airnode-utilities@^0.7.5":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@api3/airnode-utilities/-/airnode-utilities-0.7.5.tgz#5ae02514191af4849df3696809c71355f372a219"
-  integrity sha512-uiBxO/bvnAnaUMT7NxBD15oR+oO7mqQxAy8nKSx+1yQkM9Kbh6+ftuADUu0PzDnGLquKcZGbJm6ZNNOjWZ5/6w==
-  dependencies:
-    "@lifeomic/attempt" "^3.0.0"
-    date-fns "^2.16.1"
-    ethers "^5.4.5"
-
-"@api3/airnode-validator@^0.7.2", "@api3/airnode-validator@^0.7.5":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@api3/airnode-validator/-/airnode-validator-0.7.5.tgz#3ca4d92e31e6a77214f5c3d73aa82c39cbb152ba"
-  integrity sha512-WXv5Qt5fgZRrTJXoIrpgmELmN6srKbNE5cWmMdFAu+bNHa0zkiiFeKR9zIf1X7QzjmA5E+XKk6vNssP5lhYEWg==
-  dependencies:
-    "@api3/airnode-utilities" "^0.7.5"
-    "@api3/promise-utils" "^0.3.0"
-    dotenv "^16.0.0"
-    ethers "^5.4.5"
-    lodash "^4.17.21"
-    ora "^5.4.1"
-    yargs "^17.0.1"
-    zod "^3.11.6"
-
-"@api3/operations@^0.0.1-785b20f7ad527ae63c0f47f2a876da6c15c9a437":
-  version "0.0.1-785b20f7ad527ae63c0f47f2a876da6c15c9a437"
-  resolved "https://registry.yarnpkg.com/@api3/operations/-/operations-0.0.1-785b20f7ad527ae63c0f47f2a876da6c15c9a437.tgz#a15ee8d133eba8bd2c42660c4ac4d17c7352b8ce"
-  integrity sha512-xN6IAd7XX37U9yjGf9nvGIjvvSR0gN17yGL8ZcvGTDvlSdlecIgNiQUzfZVHRSEN1tJMeD6atkk0+884eIHUrA==
-  dependencies:
-    "@api3/airnode-admin" "^0.7.2"
-    "@api3/airnode-validator" "^0.7.2"
-    zod "^3.14.2"
-
-"@api3/promise-utils@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@api3/promise-utils/-/promise-utils-0.3.0.tgz#e7ebf92bfd8c1d39983321fc5445070c51fce176"
-  integrity sha512-fH3CzEcsCQjoX6BZ5M+3yRIXZ2zz4/nFdzKUB4wvn3KjvvzvroHFZrzhbKa4mB9E4AS0xnou1AXhlrnN5Fcy+A==
+    "@openzeppelin/contracts" "^4.4.2"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.18.6":
   version "7.18.6"
@@ -1038,7 +979,7 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@lifeomic/attempt@^3.0.0":
+"@lifeomic/attempt@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@lifeomic/attempt/-/attempt-3.0.3.tgz#e742a5b85eb673e2f1746b0f39cb932cbc6145bb"
   integrity sha512-GlM2AbzrErd/TmLL3E8hAHmb5Q7VhDJp35vIbyPVA5Rz55LZuRr8pwL3qrwwkVNo05gMX1J44gURKb4MHQZo7w==
@@ -1064,10 +1005,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@openzeppelin/contracts@4.4.2":
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.4.2.tgz#4e889c9c66e736f7de189a53f8ba5b8d789425c2"
-  integrity sha512-NyJV7sJgoGYqbtNUWgzzOGW4T6rR19FmX1IJgXGdapGPWsuMelGJn9h03nos0iqfforCbCB0iYIR0MtIuIFLLw==
+"@openzeppelin/contracts@^4.4.2":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.7.3.tgz#939534757a81f8d69cc854c7692805684ff3111e"
+  integrity sha512-dGRS0agJzu8ybo44pCIf3xBaPQN/65AIXNgK8+4gzKd5kbvlqyxryUYVLJv7fK98Seyd2hDZzVEHSWAh0Bt1Yw==
 
 "@sinclair/typebox@^0.24.1":
   version "0.24.31"
@@ -1502,24 +1443,10 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.3.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
-  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
-
 bech32@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
-
-bl@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
-  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
-  dependencies:
-    buffer "^5.5.0"
-    inherits "^2.0.4"
-    readable-stream "^3.4.0"
 
 bn.js@^4.11.9:
   version "4.12.0"
@@ -1585,14 +1512,6 @@ buffer-writer@2.0.0:
   resolved "https://registry.yarnpkg.com/buffer-writer/-/buffer-writer-2.0.0.tgz#ce7eb81a38f7829db09c873f2fbb792c0c98ec04"
   integrity sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==
 
-buffer@^5.5.0:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
-  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
-  dependencies:
-    base64-js "^1.3.1"
-    ieee754 "^1.1.13"
-
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
@@ -1630,7 +1549,7 @@ chalk@^2.0.0:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -1653,18 +1572,6 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
-cli-cursor@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
-  integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
-  dependencies:
-    restore-cursor "^3.1.0"
-
-cli-spinners@^2.5.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.7.0.tgz#f815fd30b5f9eaac02db604c7a231ed7cb2f797a"
-  integrity sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==
-
 cliui@^7.0.2:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
@@ -1673,11 +1580,6 @@ cliui@^7.0.2:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
-
-clone@^1.0.2:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
-  integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
 co@^4.6.0:
   version "4.6.0"
@@ -1746,11 +1648,6 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-date-fns@^2.16.1:
-  version "2.29.2"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.2.tgz#0d4b3d0f3dff0f920820a070920f0d9662c51931"
-  integrity sha512-0VNbwmWJDS/G3ySwFSJA3ayhbURMTJLtwM2DTxf9CWondCnh6DTNlO9JgRSq6ibf4eD0lfMJNBxUdEAHHix+bA==
-
 debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -1791,13 +1688,6 @@ deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
-
-defaults@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
-  integrity sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==
-  dependencies:
-    clone "^1.0.2"
 
 define-properties@^1.1.3, define-properties@^1.1.4:
   version "1.1.4"
@@ -1852,11 +1742,6 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
-
-dotenv@^16.0.0:
-  version "16.0.1"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.1.tgz#8f8f9d94876c35dac989876a5d3a82a267fdce1d"
-  integrity sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==
 
 electron-to-chromium@^1.4.202:
   version "1.4.235"
@@ -2129,7 +2014,7 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-ethers@^5.4.5, ethers@^5.7.0:
+ethers@^5.7.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.0.tgz#0055da174b9e076b242b8282638bc94e04b39835"
   integrity sha512-5Xhzp2ZQRi0Em+0OkOcRHxPzCfoBfgtOQA+RUylSkuHbhTEaQklnYi2hsWbRgs3ztJsXVXd9VKBcO1ScWL8YfA==
@@ -2509,11 +2394,6 @@ husky@^8.0.1:
   resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.1.tgz#511cb3e57de3e3190514ae49ed50f6bc3f50b3e9"
   integrity sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==
 
-ieee754@^1.1.13:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
-  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
-
 ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
@@ -2623,11 +2503,6 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   dependencies:
     is-extglob "^2.1.1"
 
-is-interactive@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
-  integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
-
 is-negative-zero@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
@@ -2678,11 +2553,6 @@ is-symbol@^1.0.2, is-symbol@^1.0.3:
   integrity sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==
   dependencies:
     has-symbols "^1.0.2"
-
-is-unicode-supported@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
-  integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
 is-weakref@^1.0.2:
   version "1.0.2"
@@ -3258,14 +3128,6 @@ lodash@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-log-symbols@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
-  integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
-  dependencies:
-    chalk "^4.1.0"
-    is-unicode-supported "^0.1.0"
-
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
@@ -3427,7 +3289,7 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
-onetime@^5.1.0, onetime@^5.1.2:
+onetime@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
@@ -3445,21 +3307,6 @@ optionator@^0.9.1:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.3"
-
-ora@^5.4.1:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/ora/-/ora-5.4.1.tgz#1b2678426af4ac4a509008e5e4ac9e9959db9e18"
-  integrity sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==
-  dependencies:
-    bl "^4.1.0"
-    chalk "^4.1.0"
-    cli-cursor "^3.1.0"
-    cli-spinners "^2.5.0"
-    is-interactive "^1.0.0"
-    is-unicode-supported "^0.1.0"
-    log-symbols "^4.1.0"
-    strip-ansi "^6.0.0"
-    wcwidth "^1.0.1"
 
 p-limit@^2.2.0:
   version "2.3.0"
@@ -3693,15 +3540,6 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
-readable-stream@^3.4.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
-  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
-
 regexp.prototype.flags@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
@@ -3752,14 +3590,6 @@ resolve@^1.20.0, resolve@^1.22.0:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
-restore-cursor@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
-  integrity sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
-  dependencies:
-    onetime "^5.1.0"
-    signal-exit "^3.0.2"
-
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
@@ -3783,11 +3613,6 @@ safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
-
-safe-buffer@~5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 scrypt-js@3.0.1:
   version "3.0.1"
@@ -3827,7 +3652,7 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
-signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
+signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
@@ -3914,13 +3739,6 @@ string.prototype.trimstart@^1.0.5:
     call-bind "^1.0.2"
     define-properties "^1.1.4"
     es-abstract "^1.19.5"
-
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
@@ -4129,11 +3947,6 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-util-deprecate@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
-
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
@@ -4159,13 +3972,6 @@ walker@^1.0.8:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
-
-wcwidth@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
-  integrity sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==
-  dependencies:
-    defaults "^1.0.3"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"
@@ -4237,7 +4043,7 @@ yargs-parser@^21.0.0, yargs-parser@^21.0.1:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
-yargs@^17.0.1, yargs@^17.3.1:
+yargs@^17.3.1:
   version "17.5.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.5.1.tgz#e109900cab6fcb7fd44b1d8249166feb0b36e58e"
   integrity sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==
@@ -4260,7 +4066,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zod@^3.11.6, zod@^3.14.2, zod@^3.18.0:
+zod@^3.18.0:
   version "3.18.0"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.18.0.tgz#2eed58b3cafb8d9a67aa2fee69279702f584f3bc"
   integrity sha512-gwTm8RfUCe8l9rDwN5r2A17DkAa8Ez4Yl4yXqc5VqeGaXaJahzYYXbTwvhroZi0SNBqTwh/bKm2N0mpCzuw4bA==


### PR DESCRIPTION
As per Slack, adds rimraf and removes operations as dependencies.
This PR also adds airnode-protocol-v1 as a dependency and adds some light tests for `evm.ts`.

A test package is available for testing: @api3/operations-utilities@0.0.1-962d5895167f1b2e7d76926643346f7c09bd2788

Jest doesn't like the `name` config field, so I've removed that.