### PR TITLE
Make aliases hashed and opsgenie config optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api3/operations-utilities",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "description": "Utilities common to API3 operations",
   "main": "./dist/index.js",
   "types": "./dist/index.js",
@@ -10,7 +10,7 @@
   "files": [
     "dist"
   ],
-  "engine": "^16.17.0",
+  "engine": "^16 || ^18",
   "private": false,
   "publishConfig": {
     "access": "public",

--- a/src/opsgenie.ts
+++ b/src/opsgenie.ts
@@ -412,8 +412,10 @@ export const getAlertContents = (alertId: string, opsGenieConfig = DEFAULT_OPSGE
 
 export const getOpsGenieLimiter = (options: Bottleneck.ConstructorOptions = { maxConcurrent: 1, minTime: 500 }) => {
   const opsGenieLimiter = new Bottleneck(options);
-  const limitedCloseOpsGenieAlertWithAlias = opsGenieLimiter.wrap(closeOpsGenieAlertWithAlias);
-  const limitedSendToOpsGenieLowLevel = opsGenieLimiter.wrap(sendToOpsGenieLowLevel);
+  const limitedCloseOpsGenieAlertWithAlias = (alias: string, config?: OpsGenieConfig) =>
+    opsGenieLimiter.schedule(() => closeOpsGenieAlertWithAlias(alias, config));
+  const limitedSendToOpsGenieLowLevel = (message: OpsGenieMessage, config?: OpsGenieConfig) =>
+    opsGenieLimiter.schedule(() => sendToOpsGenieLowLevel(message, config));
 
   return { opsGenieLimiter, limitedCloseOpsGenieAlertWithAlias, limitedSendToOpsGenieLowLevel };
 };


### PR DESCRIPTION
This might not be the best approach, but essentially the OpsGenie alert aliases are limited in length, so it might be useful to hash all inputs.

Also, we often pass down the Opsgenie config object, which is quite a hassle. I've added a fallback/optional argument for this which uses the ENV variable.

WDYT?